### PR TITLE
Add provides and requires endpoint hanlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ that user will have only read access and could collect all metrics.
 To consume this interface in your charm or layer, add the following to 
 `layer.yaml`:
 
-    includes: ['interface:mysql-monitor']
+    includes: ["interface:mysql-monitor"]
 
 ## Requires
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ The `mysql-monitor` interface is meant to be used with granted `SELECT` and
 `SHOW VIEW` privileges to every database and table for a MySQL user. This mean
 that user will have only read access and could collect all metrics. 
 
+## Layer
+
+To consume this interface in your charm or layer, add the following to 
+`layer.yaml`:
+
+    includes: ['interface:mysql-monitor']
+
 ## Requires
 
 ## Provides

--- a/provides.py
+++ b/provides.py
@@ -10,3 +10,54 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import charmhelpers.contrib.network.ip as ch_net_ip
+
+from charms.reactive import Endpoint
+from charms.reactive import set_flag, clear_flag
+from charms.reactive import not_unless, when, when_any
+
+
+class MySQLMonitor(Endpoint):
+    @property
+    def relation_ip(self):
+        """Get IP of related endpoint.
+
+        :return: IP address of related endpoint
+        :rtype: Optional[str]
+        """
+        return ch_net_ip.get_relation_ip(self.endpoint_name)
+
+    @when("endpoint.{endpoint_name}.joined")
+    def joined(self):
+        """Handle joined relation."""
+        set_flag(self.expand_name("{endpoint_name}.connected"))
+
+    @when_any("endpoint.{endpoint_name}.broken",
+              "endpoint.{endpoint_name}.departed")
+    def broken_or_departed(self):
+        """Handle broken relation."""
+        for relation in self.relations:
+            relation.to_publish_raw["host"] = None
+            relation.to_publish_raw["port"] = None
+            relation.to_publish_raw["username"] = None
+            relation.to_publish_raw["password"] = None
+
+        clear_flag(self.expand_name("{endpoint_name}.connected"))
+
+    @not_unless("{endpoint_name}.connected")
+    def provide_access(self, port, user, password):
+        """Provide a access credentials to established connection.
+
+        :param port: port to established connection with MySQL
+        :type: int
+        :param user: user to established connection with MySQL
+        :type: str
+        :param password: password to established connection with MySQL
+        :type: str
+        """
+        for relation in self.relations:
+            relation.to_publish_raw["host"] = self.relation_ip
+            relation.to_publish_raw["port"] = port
+            relation.to_publish_raw["username"] = user
+            relation.to_publish_raw["password"] = password

--- a/provides.py
+++ b/provides.py
@@ -38,10 +38,12 @@ class MySQLMonitor(Endpoint):
     def broken_or_departed(self):
         """Handle broken relation."""
         for relation in self.relations:
-            relation.to_publish_raw["host"] = None
-            relation.to_publish_raw["port"] = None
-            relation.to_publish_raw["username"] = None
-            relation.to_publish_raw["password"] = None
+            relation.to_publish.update({
+                "host": None,
+                "port": None,
+                "username": None,
+                "password": None,
+            })
 
         clear_flag(self.expand_name("{endpoint_name}.connected"))
 
@@ -57,7 +59,9 @@ class MySQLMonitor(Endpoint):
         :type: str
         """
         for relation in self.relations:
-            relation.to_publish_raw["host"] = self.relation_ip
-            relation.to_publish_raw["port"] = port
-            relation.to_publish_raw["username"] = user
-            relation.to_publish_raw["password"] = password
+            relation.to_publish.update({
+                "host": self.relation_ip,
+                "port": port,
+                "username": user,
+                "password": password,
+            })

--- a/requires.py
+++ b/requires.py
@@ -31,24 +31,24 @@ class MySQLMonitorClient(Endpoint):
     @property
     def host(self):
         """Return the host for the provided database."""
-        return self.all_joined_units.received_raw["host"]
+        return self.all_joined_units.received["host"]
 
     @property
     def port(self):
         """Return the port the provided database.
         If not available, returns the default port of 3306.
         """
-        return self.all_joined_units.received_raw.get("port", 3306)
+        return self.all_joined_units.received.get("port", 3306)
 
     @property
     def username(self):
         """Return the username for the provided database."""
-        return self.all_joined_units.received_raw["username"]
+        return self.all_joined_units.received["username"]
 
     @property
     def password(self):
         """Return the password for the provided database."""
-        return self.all_joined_units.received_raw["password"]
+        return self.all_joined_units.received["password"]
 
     def is_access_provided(self):
         """Check if all credentials are available."""

--- a/requires.py
+++ b/requires.py
@@ -10,3 +10,46 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from charms.reactive import Endpoint
+from charms.reactive import when, when_any
+from charms.reactive import set_flag, clear_flag
+
+
+class MySQLMonitorClient(Endpoint):
+    @when("endpoint.{endpoint_name}.joined")
+    def joined(self):
+        set_flag(self.expand_name("{endpoint_name}.connected"))
+
+    @when_any(
+        "endpoint.{endpoint_name}.departed",
+        "endpoint.{endpoint_name}.broken"
+    )
+    def broken_or_departed(self):
+        clear_flag(self.expand_name("{endpoint_name}.connected"))
+
+    @property
+    def host(self):
+        """Return the host for the provided database."""
+        return self.all_joined_units.received_raw["host"]
+
+    @property
+    def port(self):
+        """Return the port the provided database.
+        If not available, returns the default port of 3306.
+        """
+        return self.all_joined_units.received_raw.get("port", 3306)
+
+    @property
+    def username(self):
+        """Return the username for the provided database."""
+        return self.all_joined_units.received_raw["username"]
+
+    @property
+    def password(self):
+        """Return the password for the provided database."""
+        return self.all_joined_units.received_raw["password"]
+
+    def is_access_provided(self):
+        """Check if all credentials are available."""
+        return all([self.host, self.port, self.username, self.password])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,5 @@
+charms.reactive
+flake8>=2.2.4
+mock>=1.2
+stestr>=2.2.0
+git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,34 @@
+
+[tox]
+envlist = pep8,py3
+skipsdist = True
+
+[testenv]
+setenv = VIRTUAL_ENV={envdir}
+         PYTHONHASHSEED=0
+install_command =
+  pip install {opts} {packages}
+commands = stestr run {posargs} --test-path unit_tests/
+deps = -r{toxinidir}/test-requirements.txt
+
+[testenv:py36]
+basepython = python3.6
+
+[testenv:py37]
+basepython = python3.7
+
+[testenv:py3]
+basepython = python3
+
+[testenv:pep8]
+basepython = python3
+commands = flake8 {posargs}
+
+[testenv:venv]
+basepython = python3
+commands = {posargs}
+
+[flake8]
+import-order-style = pep8
+max-line-length = 89
+max-complexity = 10

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mock out charmhelpers so that we can test without it.
+import charms_openstack.test_mocks  # noqa
+charms_openstack.test_mocks.mock_charmhelpers()

--- a/unit_tests/test_provides.py
+++ b/unit_tests/test_provides.py
@@ -1,0 +1,102 @@
+# Copyright 2021 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import charms_openstack.test_utils as test_utils
+import mock
+
+import provides
+
+
+class TestRegisteredHooks(test_utils.TestRegisteredHooks):
+
+    def test_hooks(self):
+        defaults = []
+        hook_set = {
+            "when": {
+                "joined": ("endpoint.{endpoint_name}.joined",),
+            },
+            "when_any": {
+                "broken_or_departed": (
+                    "endpoint.{endpoint_name}.departed",
+                    "endpoint.{endpoint_name}.broken",
+                ),
+            },
+            "not_unless": {
+                "provide_access": ("{endpoint_name}.connected", )
+            }
+        }
+        # test that the hooks were registered
+        self.registered_hooks_test_helper(provides, hook_set, defaults)
+
+
+class TestMySQLMonitorProvides(test_utils.PatchHelper):
+
+    def setUp(self):
+        super().setUp()
+        self._patches = {}
+        self._patches_start = {}
+        self.patch_object(provides, "clear_flag")
+        self.patch_object(provides, "set_flag")
+        self.patch_object(provides.ch_net_ip, "get_relation_ip",
+                          return_value="10.10.10.10")
+
+        self.fake_unit = mock.MagicMock()
+        self.fake_unit.unit_name = "mysql-innodb-cluster/4"
+
+        self.fake_relation_id = "db-monitor:42"
+        self.fake_relation = mock.MagicMock()
+        self.fake_relation.relation_id = self.fake_relation_id
+        self.fake_relation.units = [self.fake_unit]
+
+        self.ep_name = "db-monitor"
+        self.ep = provides.MySQLMonitor(
+            self.ep_name, [self.fake_relation_id])
+        self.ep.relations[0] = self.fake_relation
+
+    def tearDown(self):
+        self.ep = None
+        for k, v in self._patches.items():
+            v.stop()
+            setattr(self, k, None)
+        self._patches = None
+        self._patches_start = None
+
+    def test_joined(self):
+        self.ep.joined()
+        self.set_flag.assert_called_once_with(
+            "{}.connected".format(self.ep_name)
+        )
+
+    def test_departed_or_broken(self):
+        self.ep.broken_or_departed()
+        _calls = [
+            mock.call("host", None),
+            mock.call("port", None),
+            mock.call("username", None),
+            mock.call("password", None),
+        ]
+        self.clear_flag.assert_called_once_with(
+            "{}.connected".format(self.ep_name)
+        )
+        self.fake_relation.to_publish_raw.__setitem__.assert_has_calls(_calls)
+
+    def test_provide_access(self):
+        self.ep.provide_access(3306, "user", "password")
+        _calls = [
+            mock.call("host", "10.10.10.10"),
+            mock.call("port", 3306),
+            mock.call("username", "user"),
+            mock.call("password", "password"),
+        ]
+        self.fake_relation.to_publish_raw.__setitem__.assert_has_calls(_calls)

--- a/unit_tests/test_requires.py
+++ b/unit_tests/test_requires.py
@@ -1,0 +1,106 @@
+
+# Copyright 2021 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import charms_openstack.test_utils as test_utils
+import mock
+
+import requires
+
+
+class TestRegisteredHooks(test_utils.TestRegisteredHooks):
+
+    def test_hooks(self):
+        defaults = []
+        hook_set = {
+            "when": {
+                "joined": ("endpoint.{endpoint_name}.joined",),
+            },
+            "when_any": {
+                "broken_or_departed": (
+                    "endpoint.{endpoint_name}.departed",
+                    "endpoint.{endpoint_name}.broken",
+                ),
+            }
+        }
+        # test that the hooks were registered
+        self.registered_hooks_test_helper(requires, hook_set, defaults)
+
+
+class TestMySQLMonitorRequires(test_utils.PatchHelper):
+    def setUp(self):
+        super().setUp()
+        self._patches = {}
+        self._patches_start = {}
+        self.patch_object(requires, "clear_flag")
+        self.patch_object(requires, "set_flag")
+
+        self.fake_unit = mock.MagicMock()
+        self.fake_unit.unit_name = "mysql-innodb-cluster/0"
+
+        self.fake_relation_id = "db-monitor:42"
+        self.fake_relation = mock.MagicMock()
+        self.fake_relation.relation_id = self.fake_relation_id
+        self.fake_relation.joined_units = [self.fake_unit]
+
+        self.ep_name = "db-monitor"
+        self.ep = requires.MySQLMonitorClient(
+            self.ep_name, [self.fake_relation_id]
+        )
+        self.ep.relations[0] = self.fake_relation
+
+    def tearDown(self):
+        self.ep = None
+        for k, v in self._patches.items():
+            v.stop()
+            setattr(self, k, None)
+        self._patches = None
+        self._patches_start = None
+
+    def test_joined(self):
+        self.ep.joined()
+        self.set_flag.assert_called_once_with(
+            "{}.connected".format(self.ep_name)
+        )
+
+    def test_broken_or_departed(self):
+        self.ep.broken_or_departed()
+        self.clear_flag.assert_called_once_with(
+            "{}.connected".format(self.ep_name)
+        )
+
+    def test_is_access_provided(self):
+        self.fake_unit.received_raw = {
+            "host": "10.10.10.10",
+            "port": 3306,
+            "username": "user",
+            "password": "passwd"
+        }
+
+        self.assertEqual(self.ep.host, "10.10.10.10")
+        self.assertEqual(self.ep.port, 3306)
+        self.assertEqual(self.ep.username, "user")
+        self.assertEqual(self.ep.password, "password")
+        self.assertTrue(self.ep.is_access_provided())
+
+    def test_is_access_provided_failed(self):
+        self.fake_unit.received_raw = {
+            "username": "user",
+            "password": "passwd"
+        }
+
+        self.assertEqual(self.ep.port, 3306)
+        self.assertEqual(self.ep.username, "user")
+        self.assertEqual(self.ep.password, "password")
+        self.assertFalse(self.ep.is_access_provided())


### PR DESCRIPTION
 - provides:
   - add joined, broken and departed handlers
   - add provides_access function to store credentials
 - requires:
   - add joined, broken and departed handlers
   - add host, port, username and password properties
   - add is_access_provided to check if data is provided
 - add unit_tests